### PR TITLE
[Feat][SOF-432] Upgrade `awscli` and don't uninstall `pip`

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION __PHPREDIS_VERSION__
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php7.3-cli/Dockerfile
+++ b/php7.3-cli/Dockerfile
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.3-cli/Dockerfile
+++ b/php7.3-cli/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION 4.2.0
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php7.3-cli/Dockerfile
+++ b/php7.3-cli/Dockerfile
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.3-fpm/Dockerfile
+++ b/php7.3-fpm/Dockerfile
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.3-fpm/Dockerfile
+++ b/php7.3-fpm/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION 4.2.0
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php7.3-fpm/Dockerfile
+++ b/php7.3-fpm/Dockerfile
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.4-cli/Dockerfile
+++ b/php7.4-cli/Dockerfile
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.4-cli/Dockerfile
+++ b/php7.4-cli/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:7.4-cli-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev  \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=da7be05fa1c9f68b9609726451d1aaac7dd832cb
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python2 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        && \
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*

--- a/php7.4-cli/Dockerfile
+++ b/php7.4-cli/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.2
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php7.4-cli/Dockerfile
+++ b/php7.4-cli/Dockerfile
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.4-fpm/Dockerfile
+++ b/php7.4-fpm/Dockerfile
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php7.4-fpm/Dockerfile
+++ b/php7.4-fpm/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:7.4-fpm-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev nginx \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=da7be05fa1c9f68b9609726451d1aaac7dd832cb
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python2 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        && \
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*

--- a/php7.4-fpm/Dockerfile
+++ b/php7.4-fpm/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.2
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php7.4-fpm/Dockerfile
+++ b/php7.4-fpm/Dockerfile
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php8.0-cli/Dockerfile
+++ b/php8.0-cli/Dockerfile
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php8.0-cli/Dockerfile
+++ b/php8.0-cli/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.2
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php8.0-cli/Dockerfile
+++ b/php8.0-cli/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:8.0-cli-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev  \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=da7be05fa1c9f68b9609726451d1aaac7dd832cb
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python2 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        && \
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*

--- a/php8.0-cli/Dockerfile
+++ b/php8.0-cli/Dockerfile
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php8.0-fpm/Dockerfile
+++ b/php8.0-fpm/Dockerfile
@@ -33,5 +33,4 @@ RUN apk -v --update add \
         mailcap \
         && \
     pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
-    apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php8.0-fpm/Dockerfile
+++ b/php8.0-fpm/Dockerfile
@@ -20,6 +20,7 @@ RUN chmod +x /opt/composer.phar \
     && ln -s /opt/composer.phar /usr/bin/composer
 
 # Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.2
 COPY support/install-extensions.sh /opt/install-extensions.sh
 RUN /opt/install-extensions.sh
 

--- a/php8.0-fpm/Dockerfile
+++ b/php8.0-fpm/Dockerfile
@@ -32,6 +32,6 @@ RUN apk -v --update add \
         less \
         mailcap \
         && \
-    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    pip install --upgrade awscli==1.20.11 s3cmd==2.1.0 python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/*

--- a/php8.0-fpm/Dockerfile
+++ b/php8.0-fpm/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:8.0-fpm-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev nginx \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=da7be05fa1c9f68b9609726451d1aaac7dd832cb
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python2 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        && \
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic && \
+    apk -v --purge del py-pip && \
+    rm /var/cache/apk/*

--- a/publish.sh
+++ b/publish.sh
@@ -6,8 +6,14 @@ GIT_STATUS="$(git status -s)"
 GIT_SHORT_COMMIT="$(git rev-parse --short HEAD)"
 
 REPO_NAME="carimus/laravel-alpine"
-CLI_TAG="php7.3-cli"
-FPM_TAG="php7.3-fpm"
+CLI_TAG_SUFFIX="-cli"
+FPM_TAG_SUFFIX="-fpm"
+CLI_TAG_73="php7.3$CLI_TAG_SUFFIX"
+FPM_TAG_73="php7.3$FPM_TAG_SUFFIX"
+CLI_TAG_74="php7.4$CLI_TAG_SUFFIX"
+FPM_TAG_74="php7.4$FPM_TAG_SUFFIX"
+CLI_TAG_80="php8.0$CLI_TAG_SUFFIX"
+FPM_TAG_80="php8.0$FPM_TAG_SUFFIX"
 
 if [[ -n "$GIT_STATUS" ]]; then
   echo "There are untracked changes or the working tree is dirty."
@@ -16,17 +22,61 @@ if [[ -n "$GIT_STATUS" ]]; then
 fi
 
 echo "Will build images with the following tags:"
-echo -e "Based on php:7.3-cli-alpine:\t$CLI_TAG, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$CLI_TAG"
-echo -e "Based on php:7.3-fpm-alpine:\t$FPM_TAG, $GIT_SHORT_COMMIT-$FPM_TAG"
+echo -e "Based on php:8.0-cli-alpine:\t$CLI_TAG_80, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$CLI_TAG_80"
+echo -e "Based on php:8.0-fpm-alpine:\t$FPM_TAG_80, $GIT_SHORT_COMMIT-$FPM_TAG_80"
+echo -e "Based on php:7.4-cli-alpine:\t$CLI_TAG_74, $GIT_SHORT_COMMIT-$CLI_TAG_74"
+echo -e "Based on php:7.4-fpm-alpine:\t$FPM_TAG_74, $GIT_SHORT_COMMIT-$FPM_TAG_74"
+echo -e "Based on php:7.3-cli-alpine:\t$CLI_TAG_73, $GIT_SHORT_COMMIT-$CLI_TAG_73"
+echo -e "Based on php:7.3-fpm-alpine:\t$FPM_TAG_73, $GIT_SHORT_COMMIT-$FPM_TAG_73"
 echo
 
-echo "Building image based on php:7.3-cli-alpine (default image):"
+echo "Building image based on php:8.0-cli-alpine (default image):"
 
 docker build \
-  -t carimus/laravel-alpine:$CLI_TAG \
+  -t carimus/laravel-alpine:$CLI_TAG_80 \
   -t carimus/laravel-alpine:latest \
   -t carimus/laravel-alpine:$GIT_SHORT_COMMIT \
-  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_80 \
+  -f ./php8.0-cli/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:8.0-fpm-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$FPM_TAG_80 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_80 \
+  -f ./php8.0-fpm/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:7.4-cli-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$CLI_TAG_74 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_74 \
+  -f ./php7.4-cli/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:7.4-fpm-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$FPM_TAG_74 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_74 \
+  -f ./php7.4-fpm/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:7.3-cli-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$CLI_TAG_73 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_73 \
   -f ./php7.3-cli/Dockerfile \
   .
 
@@ -35,8 +85,8 @@ echo
 echo "Building image based on php:7.3-fpm-alpine:"
 
 docker build \
-  -t carimus/laravel-alpine:$FPM_TAG \
-  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG \
+  -t carimus/laravel-alpine:$FPM_TAG_73 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_73 \
   -f ./php7.3-fpm/Dockerfile \
   .
 
@@ -44,12 +94,22 @@ echo
 
 echo "Pushing images to docker hub:"
 
-docker push carimus/laravel-alpine:$CLI_TAG
+docker push carimus/laravel-alpine:$CLI_TAG_80
 docker push carimus/laravel-alpine:latest
 docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT
-docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG
-docker push carimus/laravel-alpine:$FPM_TAG
-docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_80
+docker push carimus/laravel-alpine:$FPM_TAG_80
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_80
+
+docker push carimus/laravel-alpine:$CLI_TAG_74
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_74
+docker push carimus/laravel-alpine:$FPM_TAG_74
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_74
+
+docker push carimus/laravel-alpine:$CLI_TAG_73
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_73
+docker push carimus/laravel-alpine:$FPM_TAG_73
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_73
 
 echo
 

--- a/support/install-extensions.sh
+++ b/support/install-extensions.sh
@@ -2,6 +2,7 @@
 
 # Download phpredis sources to a dir that docker-php-ext-install will look in and make it aware it's there.
 export PHPREDIS_VERSION="${PHPREDIS_VERSION-4.2.0}"
+echo "Using phpredis version: $PHPREDIS_VERSION"
 mkdir -p /usr/src/php/ext/redis \
     && curl -L https://github.com/phpredis/phpredis/archive/$PHPREDIS_VERSION.tar.gz | tar xvz -C /usr/src/php/ext/redis --strip 1 \
     && echo 'redis' >> /usr/src/php-available-exts

--- a/update.sh
+++ b/update.sh
@@ -12,24 +12,30 @@ mkdir -p ./php8.0-fpm/
 
 cp ./Dockerfile.template ./php7.3-cli/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:7.3-cli-alpine/' ./php7.3-cli/Dockerfile
+sed -i '' 's/__PHPREDIS_VERSION__/4.2.0/' ./php7.3-cli/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__//' ./php7.3-cli/Dockerfile
 
 cp ./Dockerfile.template ./php7.3-fpm/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:7.3-fpm-alpine/' ./php7.3-fpm/Dockerfile
+sed -i '' 's/__PHPREDIS_VERSION__/4.2.0/' ./php7.3-fpm/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__/nginx/' ./php7.3-fpm/Dockerfile
 
 cp ./Dockerfile.template ./php7.4-cli/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:7.4-cli-alpine/' ./php7.4-cli/Dockerfile
+sed -i '' 's/__PHPREDIS_VERSION__/5.3.2/' ./php7.4-cli/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__//' ./php7.4-cli/Dockerfile
 
 cp ./Dockerfile.template ./php7.4-fpm/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:7.4-fpm-alpine/' ./php7.4-fpm/Dockerfile
+sed -i '' 's/__PHPREDIS_VERSION__/5.3.2/' ./php7.4-fpm/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__/nginx/' ./php7.4-fpm/Dockerfile
 
 cp ./Dockerfile.template ./php8.0-cli/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:8.0-cli-alpine/' ./php8.0-cli/Dockerfile
+sed -i '' 's/__PHPREDIS_VERSION__/5.3.2/' ./php8.0-cli/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__//' ./php8.0-cli/Dockerfile
 
 cp ./Dockerfile.template ./php8.0-fpm/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:8.0-fpm-alpine/' ./php8.0-fpm/Dockerfile
+sed -i '' 's/__PHPREDIS_VERSION__/5.3.2/' ./php8.0-fpm/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__/nginx/' ./php8.0-fpm/Dockerfile

--- a/update.sh
+++ b/update.sh
@@ -2,9 +2,13 @@
 
 set -e
 
-rm -rf ./php7.3-cli/ ./php7.3-fpm/
+rm -rf ./php7.3-cli/ ./php7.3-fpm/ ./php7.4-cli/ ./php7.4-fpm/ ./php8.0-cli/ ./php8.0-fpm/
 mkdir -p ./php7.3-cli/
 mkdir -p ./php7.3-fpm/
+mkdir -p ./php7.4-cli/
+mkdir -p ./php7.4-fpm/
+mkdir -p ./php8.0-cli/
+mkdir -p ./php8.0-fpm/
 
 cp ./Dockerfile.template ./php7.3-cli/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:7.3-cli-alpine/' ./php7.3-cli/Dockerfile
@@ -13,3 +17,19 @@ sed -i '' 's/__EXTRA_APK_PACKAGES__//' ./php7.3-cli/Dockerfile
 cp ./Dockerfile.template ./php7.3-fpm/Dockerfile
 sed -i '' 's/__BASE_IMAGE__/php:7.3-fpm-alpine/' ./php7.3-fpm/Dockerfile
 sed -i '' 's/__EXTRA_APK_PACKAGES__/nginx/' ./php7.3-fpm/Dockerfile
+
+cp ./Dockerfile.template ./php7.4-cli/Dockerfile
+sed -i '' 's/__BASE_IMAGE__/php:7.4-cli-alpine/' ./php7.4-cli/Dockerfile
+sed -i '' 's/__EXTRA_APK_PACKAGES__//' ./php7.4-cli/Dockerfile
+
+cp ./Dockerfile.template ./php7.4-fpm/Dockerfile
+sed -i '' 's/__BASE_IMAGE__/php:7.4-fpm-alpine/' ./php7.4-fpm/Dockerfile
+sed -i '' 's/__EXTRA_APK_PACKAGES__/nginx/' ./php7.4-fpm/Dockerfile
+
+cp ./Dockerfile.template ./php8.0-cli/Dockerfile
+sed -i '' 's/__BASE_IMAGE__/php:8.0-cli-alpine/' ./php8.0-cli/Dockerfile
+sed -i '' 's/__EXTRA_APK_PACKAGES__//' ./php8.0-cli/Dockerfile
+
+cp ./Dockerfile.template ./php8.0-fpm/Dockerfile
+sed -i '' 's/__BASE_IMAGE__/php:8.0-fpm-alpine/' ./php8.0-fpm/Dockerfile
+sed -i '' 's/__EXTRA_APK_PACKAGES__/nginx/' ./php8.0-fpm/Dockerfile


### PR DESCRIPTION
This is based off of https://github.com/Carimus/docker-laravel-alpine/pull/3 which should be merged first.

Relevant changes / commit range: https://github.com/Carimus/docker-laravel-alpine/pull/4/files/72351221822dc525b4416353f65574d288c51f23..e1febdda894cbbe4019e881add10a1f95c7ccf12

Uninstalling pip was causing shared deps between pip and awscli to get removed as well.

These are already published to docker hub, both for the latest tags and prefixed with `e1febdd-`