### PR TITLE
feat: add PHP 8.1, PHP 8.2 images

### DIFF
--- a/php8.1-cli/Dockerfile
+++ b/php8.1-cli/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:8.1-cli-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev  \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=70527179915d55b3811bebaec55926afd331091b
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.7
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python3 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        aws-cli \
+        s3cmd \
+        && \
+    pip install --upgrade python-magic && \
+    rm /var/cache/apk/*

--- a/php8.1-fpm/Dockerfile
+++ b/php8.1-fpm/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:8.1-fpm-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev nginx \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=70527179915d55b3811bebaec55926afd331091b
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.7
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python3 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        aws-cli \
+        s3cmd \
+        && \
+    pip install --upgrade python-magic && \
+    rm /var/cache/apk/*

--- a/php8.2-cli/Dockerfile
+++ b/php8.2-cli/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:8.2-cli-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev  \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=70527179915d55b3811bebaec55926afd331091b
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.7
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python3 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        aws-cli \
+        s3cmd \
+        && \
+    pip install --upgrade python-magic && \
+    rm /var/cache/apk/*

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -1,0 +1,38 @@
+FROM php:8.2-fpm-alpine
+
+WORKDIR /opt
+
+# Install apk packages we want
+RUN apk add -Uuv \
+    git bash supervisor freetype-dev libjpeg-turbo-dev libzip-dev \
+    libpng-dev postgresql-dev nginx \
+    && rm -rf /var/cache/apk/*
+
+# Install wait-for-it
+RUN curl https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /opt/wait-for-it.sh \
+    && chmod +x /opt/wait-for-it.sh \
+    && ln -s /opt/wait-for-it.sh /usr/bin/wait-for-it
+
+# Download and install composer
+ARG COMPOSER_COMMIT_HASH=70527179915d55b3811bebaec55926afd331091b
+RUN wget https://raw.githubusercontent.com/composer/getcomposer.org/${COMPOSER_COMMIT_HASH}/web/installer -O - -q | php -- --quiet
+RUN chmod +x /opt/composer.phar \
+    && ln -s /opt/composer.phar /usr/bin/composer
+
+# Install PHP extensions
+ENV PHPREDIS_VERSION 5.3.7
+COPY support/install-extensions.sh /opt/install-extensions.sh
+RUN /opt/install-extensions.sh
+
+# Install awscli
+RUN apk -v --update add \
+        python3 \
+        py-pip \
+        groff \
+        less \
+        mailcap \
+        aws-cli \
+        s3cmd \
+        && \
+    pip install --upgrade python-magic && \
+    rm /var/cache/apk/*

--- a/publish.sh
+++ b/publish.sh
@@ -14,6 +14,10 @@ CLI_TAG_74="php7.4$CLI_TAG_SUFFIX"
 FPM_TAG_74="php7.4$FPM_TAG_SUFFIX"
 CLI_TAG_80="php8.0$CLI_TAG_SUFFIX"
 FPM_TAG_80="php8.0$FPM_TAG_SUFFIX"
+CLI_TAG_81="php8.1$CLI_TAG_SUFFIX"
+FPM_TAG_81="php8.1$FPM_TAG_SUFFIX"
+CLI_TAG_82="php8.2$CLI_TAG_SUFFIX"
+FPM_TAG_82="php8.2$FPM_TAG_SUFFIX"
 
 if [[ -n "$GIT_STATUS" ]]; then
   echo "There are untracked changes or the working tree is dirty."
@@ -22,7 +26,11 @@ if [[ -n "$GIT_STATUS" ]]; then
 fi
 
 echo "Will build images with the following tags:"
-echo -e "Based on php:8.0-cli-alpine:\t$CLI_TAG_80, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$CLI_TAG_80"
+echo -e "Based on php:8.2-cli-alpine:\t$CLI_TAG_82, latest, $GIT_SHORT_COMMIT, $GIT_SHORT_COMMIT-$CLI_TAG_82"
+echo -e "Based on php:8.2-fpm-alpine:\t$FPM_TAG_82, $GIT_SHORT_COMMIT-$FPM_TAG_82"
+echo -e "Based on php:8.1-cli-alpine:\t$CLI_TAG_81, $GIT_SHORT_COMMIT-$CLI_TAG_81"
+echo -e "Based on php:8.1-fpm-alpine:\t$FPM_TAG_81, $GIT_SHORT_COMMIT-$FPM_TAG_81"
+echo -e "Based on php:8.0-cli-alpine:\t$CLI_TAG_80, $GIT_SHORT_COMMIT-$CLI_TAG_80"
 echo -e "Based on php:8.0-fpm-alpine:\t$FPM_TAG_80, $GIT_SHORT_COMMIT-$FPM_TAG_80"
 echo -e "Based on php:7.4-cli-alpine:\t$CLI_TAG_74, $GIT_SHORT_COMMIT-$CLI_TAG_74"
 echo -e "Based on php:7.4-fpm-alpine:\t$FPM_TAG_74, $GIT_SHORT_COMMIT-$FPM_TAG_74"
@@ -30,12 +38,52 @@ echo -e "Based on php:7.3-cli-alpine:\t$CLI_TAG_73, $GIT_SHORT_COMMIT-$CLI_TAG_7
 echo -e "Based on php:7.3-fpm-alpine:\t$FPM_TAG_73, $GIT_SHORT_COMMIT-$FPM_TAG_73"
 echo
 
-echo "Building image based on php:8.0-cli-alpine (default image):"
+echo "Building image based on php:8.2-cli-alpine (default image):"
+
+docker build \
+  -t carimus/laravel-alpine:$CLI_TAG_82 \
+  -t carimus/laravel-alpine:latest \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_82 \
+  -f ./php8.2-cli/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:8.2-fpm-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$FPM_TAG_82 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_82 \
+  -f ./php8.2-fpm/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:8.1-cli-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$CLI_TAG_81 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_81 \
+  -f ./php8.1-cli/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:8.1-fpm-alpine:"
+
+docker build \
+  -t carimus/laravel-alpine:$FPM_TAG_81 \
+  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_81 \
+  -f ./php8.1-fpm/Dockerfile \
+  .
+
+echo
+
+echo "Building image based on php:8.0-cli-alpine:"
 
 docker build \
   -t carimus/laravel-alpine:$CLI_TAG_80 \
-  -t carimus/laravel-alpine:latest \
-  -t carimus/laravel-alpine:$GIT_SHORT_COMMIT \
   -t carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_80 \
   -f ./php8.0-cli/Dockerfile \
   .
@@ -94,9 +142,19 @@ echo
 
 echo "Pushing images to docker hub:"
 
-docker push carimus/laravel-alpine:$CLI_TAG_80
+docker push carimus/laravel-alpine:$CLI_TAG_82
 docker push carimus/laravel-alpine:latest
 docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_82
+docker push carimus/laravel-alpine:$FPM_TAG_82
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_82
+
+docker push carimus/laravel-alpine:$CLI_TAG_81
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_81
+docker push carimus/laravel-alpine:$FPM_TAG_81
+docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_81
+
+docker push carimus/laravel-alpine:$CLI_TAG_80
 docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$CLI_TAG_80
 docker push carimus/laravel-alpine:$FPM_TAG_80
 docker push carimus/laravel-alpine:$GIT_SHORT_COMMIT-$FPM_TAG_80


### PR DESCRIPTION
### What has been done
- Add images for PHP 8.1 and 8.2
- Use python3 as python2 is no longer supported by new version of Alpine
- Install aws-cli and s3cmd via apk as they are not available as Python packages as of Python v3
- Update version of composer being used to current version
- Update PHP Redis version to current
- Update publish.sh to include building/publishing new images
- Set 8.2 to be default as it's the latest stable version of PHP

### Notes
- All images build and have been tested locally as base for SoftPro Docs portal containers (without container errors) tho there are various PHP notices/errors in packages from going from 7.4 to 8.1